### PR TITLE
Adding no write mode and logCount option.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,10 +47,20 @@ module.exports = function(grunt) {
         }
       },
 
+      // Just counting files with logging, without write
+      check: {
+        options: {
+          logCount: true
+        },
+        src: [
+          'test/input/*.css'
+        ]
+      },
+
       // This issue was discovered while investigating Issue #14, the force
       // option is not implemented by the bless parser. A custom force
       // implementation was added in version 0.2.0.
-      // 
+      //
       // This test should normally fail.
       issue_fourteen: {
         options: {
@@ -75,7 +85,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'bless:default_options', 'bless:custom_options']);
+  grunt.registerTask('test', ['clean', 'bless:default_options', 'bless:custom_options', 'bless:check']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Default value: `true`
 
 Add or remove a cache-buster parameter from the generated CSS files.
 
+#### options.logCount ####
+
+Type: `Boolean | String`
+Default value: `false`
+
+If set to `true`, you'll get output with all file selectors count. If set to `warn`, you'll get only log messages only on files that reached CSS selectors limit.
+
 ### Usage Examples ###
 
 #### Default Options ####
@@ -130,6 +137,25 @@ grunt.initConfig({
       files: {
         'tmp/below-limit.css': 'test/input/below-limit.css'
       }
+    }
+  }
+})
+```
+
+#### Without writing ####
+
+If you don't want to write blessed files, you can just set input files, without destination and add logging.
+
+```js
+grunt.initConfig({
+  bless: {
+    css: {
+      options: {
+        logCount: true
+      },
+      src: [
+        'test/input/below-limit.css'
+      ]
     }
   }
 })

--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -7,77 +7,104 @@
 
 'use strict';
 
-module.exports = function(grunt) {
-	var path = require('path'),
-		bless = require('bless'),
-		OVERWRITE_ERROR = 'The destination is the same as the source for file ',
-		OVERWRITE_EXCEPTION = 'Cowardly refusing to overwrite the source file.';
+module.exports = function (grunt) {
+    var path = require('path');
+    var bless = require('bless');
+    var util = require('util');
+    var OVERWRITE_ERROR = 'The destination is the same as the source for file ';
+    var OVERWRITE_EXCEPTION = 'Cowardly refusing to overwrite the source file.';
 
-	grunt.registerMultiTask('bless', 'Split CSS files suitable for IE', function() {
+    grunt.registerMultiTask('bless', 'Split CSS files suitable for IE', function () {
 
-		var options = this.options({
-			cacheBuster: true,
-			cleanup: true,
-			compress: false,
-			force: grunt.option('force') || false,
-			imports: true
-		});
-		grunt.log.writeflags(options, 'options');
+        var options = this.options({
+            cacheBuster: true,
+            cleanup: true,
+            compress: false,
+            logCount: false,
+            force: grunt.option('force') || false,
+            imports: true
+        });
+        grunt.log.writeflags(options, 'options');
 
-		grunt.util.async.forEach(this.files, function (input_files, next) {
-			var data = '';
+        // Taking list of files with write destination or list without dest
+        var files = this.files;
+        var fileList = files.length === 1 && !files[0].dest ? files[0].src : files;
 
-			// If we are not forcing the build refuse to overwrite the
-			// source file.
-			if (!options.force && input_files.src.indexOf(input_files.dest) >= 0) {
-				grunt.log.error(OVERWRITE_ERROR + input_files.dest);
-				throw grunt.util.error(OVERWRITE_EXCEPTION);
-			}
+        grunt.util.async.forEach(fileList, function (inputFile, next) {
+            var writeFiles = inputFile.dest ? true : false;
+            var outPutfileName = inputFile.dest || inputFile;
+            var limit = 4095;
+            var data = '';
 
-			// read and concat files
-			input_files.src.forEach(function (file) {
-				data += grunt.file.read(file);
-			});
+            // If we are not forcing the build refuse to overwrite the
+            // source file.
+            if (writeFiles) {
+                if (!options.force && inputFile.src.indexOf(inputFile.dest) >= 0) {
+                    grunt.log.error(OVERWRITE_ERROR + inputFile.dest);
+                    throw grunt.util.error(OVERWRITE_EXCEPTION);
+                }
+            }
+
+            // Read and concat files
+            if (util.isArray(inputFile.src)) {
+                inputFile.src.forEach(function (file) {
+                    data += grunt.file.read(file);
+                });
+            } else {
+                data += grunt.file.read(inputFile);
+            }
 
 
-			new (bless.Parser)({
-				output: input_files.dest,
-				options: options
-			}).parse(data, function (err, files, numSelectors) {
-				if (err) {
-					grunt.log.error(err);
-					throw grunt.util.error(err);
-				}
+            new (bless.Parser)({
+                output: outPutfileName,
+                options: options
+            }).parse(data, function (err, files, numSelectors) {
+                if (err) {
+                    grunt.log.error(err);
+                    throw grunt.util.error(err);
+                }
 
-				// print log message
-				var msg = 'Found ' + numSelectors + ' selector';
-				if (numSelectors !== 1) {
-					msg += 's';
-				}
-				msg += ', ';
-				if (files.length > 1) {
-					msg += 'splitting into ' + files.length + ' files.';
-				} else {
-					msg += 'not splitting.';
-				}
-				grunt.log.verbose.writeln(msg);
+                if (options.logCount) {
+                    var coungMsg = path.basename(outPutfileName) + ' has ' + numSelectors + ' CSS selectors.';
 
-				// write processed file(s)
-				files.forEach(function (file) {
+                    if (numSelectors > limit) {
+                        grunt.log.errorlns(coungMsg + ' IE8-9 will read only first ' + limit + '!');
+                    } else if (options.logCount !== 'warn') {
+                        grunt.log.oklns(coungMsg);
+                    }
+                }
 
-					// Because files is an array there is no way of finding the
-					// first file to add the banner without looping through them.
-					// 
-					// Since we are already doing that...
+                // print log message
+                var msg = 'Found ' + numSelectors + ' selector';
+                if (numSelectors !== 1) {
+                    msg += 's';
+                }
+                msg += ', ';
+                if (files.length > 1) {
+                    msg += 'splitting into ' + files.length + ' files.';
+                } else {
+                    msg += 'not splitting.';
+                }
+                grunt.log.verbose.writeln(msg);
 
-					if (options.banner && file.filename === input_files.dest) {
-						file.content = options.banner + grunt.util.linefeed + file.content;
-					}
+                // write processed file(s)
+                if (writeFiles) {
+                    files.forEach(function (file) {
 
-					grunt.file.write(file.filename, file.content);
-				});
-			});
-			next();
-		});
-	});
+                        // Because files is an array there is no way of finding the
+                        // first file to add the banner without looping through them.
+                        //
+                        // Since we are already doing that...
+
+                        if (options.banner && file.filename === file.dest) {
+                            file.content = options.banner + grunt.util.linefeed + file.content;
+                        }
+
+                        grunt.file.write(file.filename, file.content);
+                    });
+                }
+            });
+            next();
+        });
+    });
 };


### PR DESCRIPTION
Adding scenario for use case, where we don't wan't to use generated files, and call `grunt-bless` only for linting.

Also, I converted all tab characters to spaces for consistency (git blame isn't damaged, only diff on github shows too many lines).
