### PR TITLE
Adding no write mode and logCount option #2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,10 +47,20 @@ module.exports = function(grunt) {
         }
       },
 
+      // Just counting files with logging, without write
+      check: {
+        options: {
+          logCount: true
+        },
+        src: [
+          'test/input/*.css'
+        ]
+      },
+
       // This issue was discovered while investigating Issue #14, the force
       // option is not implemented by the bless parser. A custom force
       // implementation was added in version 0.2.0.
-      // 
+      //
       // This test should normally fail.
       issue_fourteen: {
         options: {
@@ -75,7 +85,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'bless:default_options', 'bless:custom_options']);
+  grunt.registerTask('test', ['clean', 'bless:default_options', 'bless:custom_options', 'bless:check']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Default value: `true`
 
 Add or remove a cache-buster parameter from the generated CSS files.
 
+#### options.logCount ####
+
+Type: `Boolean | String`
+Default value: `false`
+
+If set to `true`, you'll get output with all file selectors count. If set to `warn`, you'll get only log messages only on files that reached CSS selectors limit.
+
 ### Usage Examples ###
 
 #### Default Options ####
@@ -134,6 +141,33 @@ grunt.initConfig({
   }
 })
 ```
+
+#### Without writing ####
+
+If you don't want to write blessed files, you can just set input files, without destination and add logging.
+
+```js
+grunt.initConfig({
+  bless: {
+    css: {
+      options: {
+        logCount: true
+      },
+      src: [
+        'test/input/below-limit.css'
+      ]
+    }
+  }
+})
+```
+
+options: {
+                    imports: false,
+                    logCount: 'warn'
+                },
+                src: [
+                    '<%= cssBundlesDir %>/**/*.css'
+                ]
 
 Contributing
 ------------

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bless": "~3.0.0"
+    "bless": "~3.0.0",
+    "chalk": "~0.5.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",

--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -10,6 +10,8 @@
 module.exports = function(grunt) {
 	var path = require('path'),
 		bless = require('bless'),
+		util = require('util'),
+		chalk = require('chalk'),
 		OVERWRITE_ERROR = 'The destination is the same as the source for file ',
 		OVERWRITE_EXCEPTION = 'Cowardly refusing to overwrite the source file.';
 
@@ -19,35 +21,69 @@ module.exports = function(grunt) {
 			cacheBuster: true,
 			cleanup: true,
 			compress: false,
+            logCount: false,
 			force: grunt.option('force') || false,
+            warnLimit: 4000,
 			imports: true
 		});
 		grunt.log.writeflags(options, 'options');
 
-		grunt.util.async.forEach(this.files, function (input_files, next) {
+        // Taking list of files with write destination or list without dest
+        var files = this.files;
+        var fileList = files.length === 1 && !files[0].dest ? files[0].src : files;
+
+		grunt.util.async.forEach(fileList, function (inputFile, next) {
+            var writeFiles = inputFile.dest ? true : false;
+            var outPutfileName = inputFile.dest || inputFile;
+            var limit = 4095;
 			var data = '';
 
 			// If we are not forcing the build refuse to overwrite the
 			// source file.
-			if (!options.force && input_files.src.indexOf(input_files.dest) >= 0) {
-				grunt.log.error(OVERWRITE_ERROR + input_files.dest);
-				throw grunt.util.error(OVERWRITE_EXCEPTION);
+            if (writeFiles) {
+                if (!options.force && inputFile.src.indexOf(inputFile.dest) >= 0) {
+                    grunt.log.error(OVERWRITE_ERROR + inputFile.dest);
+                    throw grunt.util.error(OVERWRITE_EXCEPTION);
+                }
 			}
 
-			// read and concat files
-			input_files.src.forEach(function (file) {
-				data += grunt.file.read(file);
-			});
+			// Read and concat files
+            if (util.isArray(inputFile.src)) {
+                inputFile.src.forEach(function (file) {
+                    data += grunt.file.read(file);
+                });
+            } else {
+                data += grunt.file.read(inputFile);
+            }
 
 
 			new (bless.Parser)({
-				output: input_files.dest,
+				output: outPutfileName,
 				options: options
 			}).parse(data, function (err, files, numSelectors) {
 				if (err) {
 					grunt.log.error(err);
 					throw grunt.util.error(err);
 				}
+
+                if (options.logCount) {
+                    var overLimit = numSelectors > limit;
+                    var _numSelectors = chalk.green(numSelectors);
+
+                    if (overLimit) {
+                        _numSelectors = chalk.red(numSelectors);
+                    } else if (numSelectors > options.warnLimit ) {
+                        _numSelectors = chalk.yellow(numSelectors);
+                    }
+
+                    var coungMsg = path.basename(outPutfileName) + ' has ' + _numSelectors + ' CSS selectors.';
+
+                    if (overLimit) {
+                        grunt.log.errorlns(coungMsg + ' IE8-9 will read only first ' + limit + '!');
+                    } else if (options.logCount !== 'warn') {
+                        grunt.log.oklns(coungMsg);
+                    }
+                }
 
 				// print log message
 				var msg = 'Found ' + numSelectors + ' selector';
@@ -63,19 +99,21 @@ module.exports = function(grunt) {
 				grunt.log.verbose.writeln(msg);
 
 				// write processed file(s)
-				files.forEach(function (file) {
+                if (writeFiles) {
+                    files.forEach(function (file) {
 
-					// Because files is an array there is no way of finding the
-					// first file to add the banner without looping through them.
-					// 
-					// Since we are already doing that...
+                        // Because files is an array there is no way of finding the
+                        // first file to add the banner without looping through them.
+                        //
+                        // Since we are already doing that...
 
-					if (options.banner && file.filename === input_files.dest) {
-						file.content = options.banner + grunt.util.linefeed + file.content;
-					}
+                        if (options.banner && file.filename === file.dest) {
+                            file.content = options.banner + grunt.util.linefeed + file.content;
+                        }
 
-					grunt.file.write(file.filename, file.content);
-				});
+                        grunt.file.write(file.filename, file.content);
+                    });
+                }
 			});
 			next();
 		});


### PR DESCRIPTION
Adding scenario for use case, where we don't wan't to use generated files, and call grunt-bless only for linting.

Here's logging example http://d.pr/i/CPfz with logCount option.
