### PR TITLE
Added the option to skip failOnLimit when "--force" is used

### DIFF
--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
 					if (overLimit) {
 						grunt.log.errorlns(overLimitErrorMessage);
 
-						if (options.failOnLimit) {
+						if (options.failOnLimit && !options.force) {
 							throw grunt.util.error(chalk.stripColor(overLimitErrorMessage));
 						}
 					} else if (options.logCount !== 'warn') {


### PR DESCRIPTION
I just wanted to add this option because, while on my normal project Grunt config I want this to fail if "overLimit", to test exactly how many css fail, I usually also run this task alone with "--force" option.